### PR TITLE
Improve the speed of rubrick connector fact on Linux.

### DIFF
--- a/lib/facter/rubrik_connector.rb
+++ b/lib/facter/rubrik_connector.rb
@@ -10,12 +10,9 @@ Facter.add(:rubrik_connector) do
         'false'
       end
     when /(L|l)inux/ 
-      conn_status = Facter::Util::Resolution::exec("/bin/rpm -q -a | grep rubrik-agent | wc -l")
-      if conn_status == '1' then
-        'true' 
-      else
-        'false'
-      end
+      # Check to see if the rubrik-agent package is installed.
+      Facter::Core::Execution.execute("/bin/rpm --quiet -q rubrik-agent")
+      $?.success?
     end 
   end
 end


### PR DESCRIPTION
Querying the entire RPM database and then piping to grep and wc is significantly slower than just doing an 'rpm -q rubrik-agent'.

This update significantly improves the fact's speed.

`xxx@schon-01d:~/rubrik-module-for-puppet$ time /bin/rpm -q -a | grep rubrik-agent | wc -l
0

**real    0m2.142s**
user    0m1.797s
sys     0m0.389s
xxx@schon-01d:~/rubrik-module-for-puppet$ time /bin/rpm --quiet -q rubrik-agent

**real    0m0.104s**
user    0m0.057s
sys     0m0.050s
nfiiseed@nfiv-schon-01d:~/rubrik-module-for-puppet$ `